### PR TITLE
Add an option to build a statically-linked DLL

### DIFF
--- a/libass/meson.build
+++ b/libass/meson.build
@@ -52,12 +52,22 @@ if enable_asm
     libass_src += nasm_gen.process(src_intel)
 endif
 
-libass = library('ass', libass_src, config_h,
-                 c_args: fribidi_visibility,
-                 install: true,
-                 link_args: link_args,
-                 include_directories: incs,
-                 dependencies: deps)
+
+if enable_statically
+    libass = shared_library('ass', libass_src, config_h,
+                            c_args: fribidi_visibility,
+                            install: true,
+                            link_args: link_args,
+                            include_directories: incs,
+                            dependencies: deps)
+else
+    libass = library('ass', libass_src, config_h,
+                     c_args: fribidi_visibility,
+                     install: true,
+                     link_args: link_args,
+                     include_directories: incs,
+                     dependencies: deps)
+endif
 
 libass_dep = declare_dependency(link_with: libass,
                                 include_directories: incs,

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,14 @@ project('libass', 'c', license: 'ISC',
 conf = configuration_data()
 deps = []
 
+enable_statically = false
+statically_condition = get_option('compile-statically')
+compile_condition = host_machine.system() == 'windows' and get_option('default_library') == 'static'
+
+if statically_condition and compile_condition
+    enable_statically = true
+endif
+
 if host_machine.system() == 'darwin'
     add_languages('objc')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('test', type: 'boolean', value: false, description: 'enable test program (requires libpng)')
 option('profile', type: 'boolean', value: false, description: 'enable profiling program')
+option('compile-statically', type: 'boolean', value: false, description: 'Create a dll with all dependencies inside')
 
 option('fontconfig', type: 'feature', value: 'disabled', description: 'fontconfig support')
 option('harfbuzz', type: 'feature', description: 'HarfBuzz support')


### PR DESCRIPTION
After having read this [issue](https://github.com/libass/libass/issues/277), I thought it could be useful to have an option to build a statically-linked DLL for Windows. This type of DLL is used quite a lot in other projects and since `meson` simplifies its building process, I think it could be a great opportunity to add an option like this to `libass`.

The following command is an example of cross-compilation for `Windows` 32 bit.
```
meson build-windows32 \
      --buildtype release \
      -Ddirectwrite=enabled \ 
      -Ddefault_library=static \
      -Dcompile-statically=true \
      --cross-file cross_mingw_i686.txt
ninja -C build-windows32
```
Haven't tested if these changes affect the `Windows` building though.

