### PR TITLE
Update for latest FreeType2

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,92 @@
+name: Meson CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+
+    strategy:
+      matrix:
+        config:
+          - {
+            name: Windows MSVC Release,
+            os: windows-latest,
+            msvc: true,
+            buildtype: release,
+            args: '-Ddefault_library=static --force-fallback-for=zlib,harfbuzz'
+          }
+          #- {
+          #  name: Windows MinGW Release,
+          #  os: windows-latest,
+          #  msvc: false,
+          #  buildtype: release,
+          #  args: ''
+          #}
+          #- {
+          #  name: Ubuntu Debug,
+          #  os: ubuntu-latest,
+          #  buildtype: debugoptimized,
+          #  args: ''
+          #}
+          #- {
+          #  name: Ubuntu Release,
+          #  os: ubuntu-latest,
+          #  buildtype: release,
+          #  args: ''
+          #}
+          #- {
+          #  name: macOS Debug,
+          #  os: macos-latest,
+          #  buildtype: debugoptimized,
+          #  args: ''
+          #}
+          #- {
+          #  name: macOS Release,
+          #  os: macos-latest,
+          #  buildtype: release,
+          #  args: -Ddefault_library=static
+          #}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Setup Meson
+        run: |
+          python -m pip install --upgrade pip
+          pip install meson
+
+      - name: Setup MSVC
+        if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install dependencies (Windows)
+        if: matrix.config.os == 'windows-latest'
+        run: choco install ninja
+
+      - name: Install dependencies (MacOS)
+        if: matrix.config.os == 'macos-latest'
+        run: brew install nasm ninja
+
+      - name: Install dependencies (Linux)
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install ninja-build build-essential pkg-config libfreetype6-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev
+
+      - name: Configure
+        run: meson build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }}
+
+      - name: Build
+        run: meson compile -C build

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -19,15 +19,15 @@ jobs:
             os: windows-latest,
             msvc: true,
             buildtype: release,
-            args: '-Ddefault_library=static --force-fallback-for=zlib,harfbuzz'
+            args: '-Ddefault_library=static --wrap-mode=forcefallback'
           }
-          #- {
-          #  name: Windows MinGW Release,
-          #  os: windows-latest,
-          #  msvc: false,
-          #  buildtype: release,
-          #  args: ''
-          #}
+          - {
+            name: Windows MinGW Release,
+            os: windows-latest,
+            msvc: false,
+            buildtype: release,
+            args: ''
+          }
           - {
             name: Ubuntu Debug,
             os: ubuntu-latest,

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -28,18 +28,18 @@ jobs:
           #  buildtype: release,
           #  args: ''
           #}
-          #- {
-          #  name: Ubuntu Debug,
-          #  os: ubuntu-latest,
-          #  buildtype: debugoptimized,
-          #  args: ''
-          #}
-          #- {
-          #  name: Ubuntu Release,
-          #  os: ubuntu-latest,
-          #  buildtype: release,
-          #  args: ''
-          #}
+          - {
+            name: Ubuntu Debug,
+            os: ubuntu-latest,
+            buildtype: debugoptimized,
+            args: ''
+          }
+          - {
+            name: Ubuntu Release,
+            os: ubuntu-latest,
+            buildtype: release,
+            args: ''
+          }
           #- {
           #  name: macOS Debug,
           #  os: macos-latest,

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -40,18 +40,18 @@ jobs:
             buildtype: release,
             args: ''
           }
-          #- {
-          #  name: macOS Debug,
-          #  os: macos-latest,
-          #  buildtype: debugoptimized,
-          #  args: ''
-          #}
-          #- {
-          #  name: macOS Release,
-          #  os: macos-latest,
-          #  buildtype: release,
-          #  args: -Ddefault_library=static
-          #}
+          - {
+            name: macOS Debug,
+            os: macos-latest,
+            buildtype: debugoptimized,
+            args: ''
+          }
+          - {
+            name: macOS Release,
+            os: macos-latest,
+            buildtype: release,
+            args: -Ddefault_library=static
+          }
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Makefile.in
 /ltmain.sh
 /missing
 /m4
+
+# Meson
+/subprojects
+/build

--- a/libass/ass/meson.build
+++ b/libass/ass/meson.build
@@ -1,0 +1,4 @@
+# Hack to work around https://github.com/mesonbuild/meson/issues/2546
+foreach header: libass_headers
+    configure_file(copy: true, input: header, output: '@PLAINNAME@')
+endforeach

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -53,7 +53,6 @@ if enable_asm
 endif
 
 libass = library('ass', libass_src, config_h,
-                 c_args: fribidi_visibility,
                  install: true,
                  link_args: link_args,
                  include_directories: incs,

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -54,7 +54,6 @@ endif
 
 libass = library('ass', libass_src, config_h,
                  install: true,
-                 link_args: link_args,
                  include_directories: incs,
                  dependencies: deps)
 

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -1,0 +1,68 @@
+src_intel = files(
+    'x86/rasterizer.asm',
+    'x86/blend_bitmaps.asm',
+    'x86/blur.asm',
+    'x86/cpuid.asm'
+)
+src_intel64 = files('x86/be_blur.asm')
+src_fontconfig = files('ass_fontconfig.c')
+src_directwrite = files('ass_directwrite.c')
+src_coretext = files('ass_coretext.c')
+
+libass_src = files(
+    'ass.c',
+    'ass_utils.c',
+    'ass_string.c',
+    'ass_strtod.c',
+    'ass_library.c',
+    'ass_cache.c',
+    'ass_font.c',
+    'ass_fontselect.c',
+    'ass_render.c',
+    'ass_render_api.c',
+    'ass_parse.c',
+    'ass_shaper.c',
+    'ass_outline.c',
+    'ass_drawing.c',
+    'ass_rasterizer.c',
+    'ass_rasterizer_c.c',
+    'ass_bitmap.c',
+    'ass_blur.c'
+)
+
+libass_headers = files(
+    'ass.h',
+    'ass_types.h'
+)
+
+if fontconfig
+    libass_src += src_fontconfig
+endif
+if directwrite
+    libass_src += src_directwrite
+endif
+if coretext
+    libass_src += src_coretext
+endif
+
+if enable_asm
+    if bittype == '64'
+        src_intel += src_intel64
+    endif
+    libass_src += nasm_gen.process(src_intel)
+endif
+
+libass = library('ass', libass_src, config_h,
+                 c_args: fribidi_visibility,
+                 install: true,
+                 link_args: link_args,
+                 include_directories: incs,
+                 dependencies: deps)
+
+libass_dep = declare_dependency(link_with: libass,
+                                include_directories: incs,
+                                dependencies: deps,
+                                sources: config_h)
+
+install_headers(libass_headers, subdir: 'ass')
+subdir('ass')

--- a/meson.build
+++ b/meson.build
@@ -77,9 +77,8 @@ if freetype_dep.found()
     conf.set('CONFIG_FREETYPE', 1)
 endif
 
-fribidi_visibility = ''
 if host_machine.system() == 'windows' and get_option('default_library') == 'static'
-    fribidi_visibility = '-DFRIBIDI_LIB_STATIC'
+    add_project_arguments('-DFRIBIDI_LIB_STATIC', language: 'c')
 endif
 fribidi_dep = dependency('fribidi', version: '>= 0.19.0',
                          default_options: ['docs=false', 'tests=false'])

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ if cc.get_argument_syntax() == 'gcc'
         '-Wextra',
         '-Wno-sign-compare',
         '-Wno-unused-parameter',
-        '-Werror-implicit-function-declaration', 
+        '-Werror-implicit-function-declaration',
         '-Wstrict-prototypes',
         '-Wpointer-arith',
         '-Wredundant-decls',
@@ -107,7 +107,7 @@ endif
 
 # Misc deps
 # Version info omitted for freetype2 because its versioning is weird and the meson port doesn't handle it properly
-freetype_dep = dependency('freetype', 
+freetype_dep = dependency('freetype',
                           fallback: ['freetype2', 'freetype_dep'])
 if freetype_dep.found()
     deps += freetype_dep
@@ -213,7 +213,7 @@ endif
 
 # libass.pc
 pkg = import('pkgconfig')
-pkg.generate(libass, 
+pkg.generate(libass,
              name: 'libass',
              description: 'LibASS is an SSA/ASS subtitles rendering library',
              subdirs: meson.project_name())

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libass', 'c', license: 'ISC',
         meson_version: '>= 0.55.0',
-        default_options: ['c_std=gnu99', 'buildtype=debugoptimized', 'warning_level=2'],
+        default_options: ['c_std=c99', 'buildtype=debugoptimized', 'warning_level=2'],
         version: '0.15.0')
 
 conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ deps = []
 # Compiler setup
 
 cc = meson.get_compiler('c')
+
 if cc.get_argument_syntax() == 'gcc'
     cflags = [
         '-Wno-sign-compare',
@@ -21,6 +22,11 @@ if cc.get_argument_syntax() == 'gcc'
     ]
     add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 endif
+
+if host_machine.system() != 'windows'
+    add_project_arguments('-D_GNU_SOURCE', language: 'c')
+endif
+
 link_args = cc.get_supported_link_arguments(['-prefer-non-pic'])
 
 # Configuration

--- a/meson.build
+++ b/meson.build
@@ -106,8 +106,7 @@ else
 endif
 
 # Misc deps
-# Version info omitted for freetype2 because its versioning is weird and the meson port doesn't handle it properly
-freetype_dep = dependency('freetype',
+freetype_dep = dependency('freetype', version: '>= 2.2.1',
                           fallback: ['freetype2', 'freetype_dep'])
 if freetype_dep.found()
     deps += freetype_dep

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libass', 'c', license: 'ISC',
         meson_version: '>= 0.49.0',
         default_options: ['c_std=gnu99'],
-        version: '0.14.0')
+        version: '0.15.0')
 
 conf = configuration_data()
 deps = []

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('libass', 'c', license: 'ISC',
         meson_version: '>= 0.55.0',
-        default_options: ['c_std=c99', 'buildtype=debugoptimized', 'warning_level=2'],
+        # cpp_std specified because meson compiler options are currently global
+        default_options: ['c_std=c99', 'cpp_std=c++11', 'buildtype=debugoptimized', 'warning_level=2'],
         version: '0.15.0')
 
 conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -116,12 +116,10 @@ endif
 
 have_visibility_hidden = cc.has_argument('-fvisibility=hidden')
 if have_visibility_hidden
-    fribidi_visibility = '-DFRIBIDI_ENTRY=extern __attribute__ ((visibility ("default")))'
+    fribidi_visibility = '-DFRIBIDI_ENTRY=__attribute__ ((visibility ("default")))'
 else
-    if get_option('default_library') != 'static' and host_machine.system() == 'windows'
-        fribidi_visibility = '-DFRIBIDI_ENTRY=__declspec(dllexport)'
-    else
-        fribidi_visibility = '-DFRIBIDI_ENTRY=extern'
+    if host_machine.system() == 'windows' and get_option('default_library') == 'static'
+        fribidi_visibility = '-DFRIBIDI_LIB_STATIC'
     endif
 endif
 fribidi_dep = dependency('fribidi', version: '>= 0.19.0',

--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ endif
 
 # Misc deps
 freetype_dep = dependency('freetype', version: '>= 2.2.1',
-                          fallback: ['freetype2', 'freetype_dep'])
+                          fallback: ['freetype2', 'freetype2_dep'])
 if freetype_dep.found()
     deps += freetype_dep
     conf.set('CONFIG_FREETYPE', 1)

--- a/meson.build
+++ b/meson.build
@@ -6,10 +6,6 @@ project('libass', 'c', license: 'ISC',
 conf = configuration_data()
 deps = []
 
-if host_machine.system() == 'darwin'
-    add_languages('objc')
-endif
-
 if get_option('large-tiles')
     conf.set('CONFIG_LARGE_TILES', 1)
 endif

--- a/meson.build
+++ b/meson.build
@@ -123,7 +123,7 @@ else
 endif
 fribidi_dep = dependency('fribidi', version: '>= 0.19.0',
                          fallback: ['fribidi', 'libfribidi_dep'],
-                         default_options: ['docs=false'])
+                         default_options: ['docs=false', 'tests=false'])
 if fribidi_dep.found()
     deps += fribidi_dep
     conf.set('CONFIG_FRIBIDI', 1)

--- a/meson.build
+++ b/meson.build
@@ -112,13 +112,9 @@ if freetype_dep.found()
     conf.set('CONFIG_FREETYPE', 1)
 endif
 
-have_visibility_hidden = cc.has_argument('-fvisibility=hidden')
-if have_visibility_hidden
-    fribidi_visibility = '-DFRIBIDI_ENTRY=__attribute__ ((visibility ("default")))'
-else
-    if host_machine.system() == 'windows' and get_option('default_library') == 'static'
-        fribidi_visibility = '-DFRIBIDI_LIB_STATIC'
-    endif
+fribidi_visibility = ''
+if host_machine.system() == 'windows' and get_option('default_library') == 'static'
+    fribidi_visibility = '-DFRIBIDI_LIB_STATIC'
 endif
 fribidi_dep = dependency('fribidi', version: '>= 0.19.0',
                          default_options: ['docs=false', 'tests=false'])

--- a/meson.build
+++ b/meson.build
@@ -31,31 +31,10 @@ if cc.get_argument_syntax() == 'gcc'
 endif
 link_args = cc.get_supported_link_arguments(['-prefer-non-pic'])
 
-check_headers = [
-    'dlfcn.h',
-    'iconv.h',
-    'inttypes.h',
-    'memory.h',
-    'stdbool.h',
-    'stdint.h',
-    'stdlib.h',
-    'string.h',
-    'strings.h',
-    'sys/stat.h',
-    'sys/types.h',
-    'unistd.h'
-]
-
 check_functions = [
     'strdup',
     'strndup'
 ]
-
-m_dep = cc.find_library('m', required: false)
-if m_dep.found()
-    deps += m_dep
-    conf.set('HAVE_LIBM', 1)
-endif
 
 iconv_dep = cc.find_library('iconv', required: false)
 if iconv_dep.found()
@@ -193,12 +172,6 @@ if get_option('require-system-font-provider') and not fontconfig and not directw
     error('''Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig (Linux, other) is required.
 If you really want to compile without a system font provider, set -Drequire-system-font-provider=false''')
 endif
-
-foreach name: check_headers
-    if cc.has_header(name)
-        conf.set('HAVE_@0@'.format(name.to_upper().underscorify()), 1)
-    endif
-endforeach
 
 foreach name: check_functions
     if cc.has_function(name)

--- a/meson.build
+++ b/meson.build
@@ -24,8 +24,17 @@ if cc.get_argument_syntax() == 'gcc'
     add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 endif
 
-if host_machine.system() != 'windows'
+test_args = []
+
+if host_machine.system() == 'linux'
+    test_args += '-D_GNU_SOURCE'
     add_project_arguments('-D_GNU_SOURCE', language: 'c')
+elif host_machine.system() == 'darwin'
+    test_args += '-D_DARWIN_C_SOURCE'
+    add_project_arguments('-D_DARWIN_C_SOURCE', language: 'c')
+elif cc.get_id() != 'msvc'
+    test_args += '-D_POSIX_C_SOURCE=200809L'
+    add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
 endif
 
 link_args = cc.get_supported_link_arguments(['-prefer-non-pic'])
@@ -39,13 +48,13 @@ endif
 conf.set('PACKAGE_NAME', 'libass')
 conf.set('PACKAGE_VERSION', meson.project_version())
 
-check_functions = [
+str_check_functions = [
     'strdup',
     'strndup'
 ]
 
-foreach name: check_functions
-    if cc.has_function(name) # TODO: this is probably still wrong
+foreach name: str_check_functions
+    if cc.has_function(name) and cc.has_header_symbol('string.h', name, args: test_args) # might be wrong with MSVC?
         conf.set('HAVE_@0@'.format(name.to_upper()), 1)
     endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -125,7 +125,7 @@ endif
 
 harfbuzz_options = ['tests=disabled']
 if host_machine.system() == 'windows'
-    harfbuzz_options += ['glib=disabled', 'gobject=disabled']
+    harfbuzz_options += ['glib=disabled', 'gobject=disabled', 'fontconfig=disabled', 'cairo=disabled']
 endif
 harfbuzz_dep = dependency('harfbuzz', version: '>= 0.9.5', required: get_option('harfbuzz'),
                           fallback: ['harfbuzz', 'libharfbuzz_dep'],

--- a/meson.build
+++ b/meson.build
@@ -106,8 +106,7 @@ if enable_asm
 endif
 
 # Misc deps
-freetype_dep = dependency('freetype', version: '>= 2.2.1',
-                          fallback: ['freetype2', 'freetype2_dep'])
+freetype_dep = dependency('freetype', version: '>= 2.2.1')
 if freetype_dep.found()
     deps += freetype_dep
     conf.set('CONFIG_FREETYPE', 1)
@@ -122,15 +121,19 @@ else
     endif
 endif
 fribidi_dep = dependency('fribidi', version: '>= 0.19.0',
-                         fallback: ['fribidi', 'libfribidi_dep'],
                          default_options: ['docs=false', 'tests=false'])
 if fribidi_dep.found()
     deps += fribidi_dep
     conf.set('CONFIG_FRIBIDI', 1)
 endif
 
+harfbuzz_options = []
+if host_machine.system() == 'windows'
+    harfbuzz_options += ['glib=disabled', 'gobject=disabled']
+endif
 harfbuzz_dep = dependency('harfbuzz', version: '>= 0.9.5', required: get_option('harfbuzz'),
-                          fallback: ['harfbuzz', 'libharfbuzz_dep'])
+                          fallback: 'harfbuzz',
+                          default_options: harfbuzz_options)
 if harfbuzz_dep.found()
     deps += harfbuzz_dep
     conf.set('CONFIG_HARFBUZZ', 1)
@@ -151,8 +154,7 @@ if fontconfig_dep.found()
 endif
 
 if get_option('test')
-    deps += dependency('libpng', version: '>= 1.2.0',
-                       fallback: ['libpng', 'png_dep'])
+    deps += dependency('libpng', version: '>= 1.2.0')
     conf.set('CONFIG_LIBPNG', 1)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -106,10 +106,14 @@ if enable_asm
 endif
 
 # Misc deps
-freetype_dep = dependency('freetype', version: '>= 2.2.1',
-                          default_options: ['default_library=' + get_option('default_library'), # workaround for https://github.com/mesonbuild/meson/issues/8047
-                                            'zlib=builtin',
-                                            'png=enabled'])
+freetype_dep = dependency('freetype', version: '>= 2.10.92', required: false)
+if not freetype_dep.found()
+    freetype_sp = subproject('freetype2',
+                             default_options: ['default_library=' + get_option('default_library'), # workaround for https://github.com/mesonbuild/meson/issues/8047
+                                               'zlib=builtin',
+                                               'png=enabled'])
+    freetype_dep = freetype_sp.get_variable('freetype2_dep')
+endif
 if freetype_dep.found()
     deps += freetype_dep
     conf.set('CONFIG_FREETYPE', 1)

--- a/meson.build
+++ b/meson.build
@@ -154,8 +154,8 @@ nasm_args = []
 nasm = find_program('nasm', required: get_option('asm'))
 enable_asm = nasm.found()
 
+# NASM version check
 if enable_asm
-    # NASM version check
     nasm_r = run_command(nasm, '-v')
     out = nasm_r.stdout().strip().split()
     if out[1].to_lower() == 'version'
@@ -169,7 +169,7 @@ if enable_asm
     endif
 endif
 
-# Architecture check
+# Architecture check - TODO x32
 if host_machine.cpu_family() == 'x86'
     bittype = '32'
     nasm_args += '-DARCH_X86_64=0'
@@ -189,19 +189,28 @@ elif (not enable_asm) and intel
     warning('Install nasm-2.10 or later for a significantly faster libass build.')
 endif
 
+# System check
 if enable_asm
-    conf.set('CONFIG_ASM', 1)
-
-    if host_machine.system() == 'windows'
+    host_system = host_machine.system()
+    if host_system == 'windows'
         nasm_args += ['-f', 'win' + bittype]
         if bittype == '32'
             nasm_args += '-DPREFIX'
         endif
-    elif host_machine.system() == 'darwin'
+    elif host_system == 'darwin'
         nasm_args += ['-f', 'macho' + bittype, '-DPREFIX', '-DSTACK_ALIGNMENT=16']
-    else
+    elif host_system == 'linux' or host_system == 'sunos' or host_system == 'haiku'
         nasm_args += ['-f', 'elf' + bittype, '-DSTACK_ALIGNMENT=16']
+    elif host_system == 'dragonfly' or host_system.endswith('bsd')
+        nasm_args += ['-f', 'elf' + bittype]
+    else
+        warning('Please contact libass upstream to figure out if ASM support for your platform can be added. In the meantime, disabling.')
+        enable_asm = false
     endif
+endif
+
+if enable_asm
+    conf.set('CONFIG_ASM', 1)
 
     nasm_args += '-Dprivate_prefix=ass'
     nasm_args += ['-I', meson.current_source_dir() / 'libass' + '/', '-o', '@OUTPUT@', '@INPUT@']

--- a/meson.build
+++ b/meson.build
@@ -67,23 +67,27 @@ if enable_asm
     endif
 endif
 
-if enable_asm
-    # Architecture check
-    if host_machine.cpu_family() == 'x86'
-        bittype = '32'
-        nasm_args += '-DARCH_X86_64=0'
-    elif host_machine.cpu_family() == 'x86_64'
-        bittype = '64'
-        nasm_args += ['-DARCH_X86_64=1', '-DPIC']
-    else
-        warning('ASM functions are not available on non-intel machines; disabling.')
-        enable_asm = false
-    endif
+# Architecture check
+if host_machine.cpu_family() == 'x86'
+    bittype = '32'
+    nasm_args += '-DARCH_X86_64=0'
+    intel = true
+elif host_machine.cpu_family() == 'x86_64'
+    bittype = '64'
+    nasm_args += ['-DARCH_X86_64=1', '-DPIC']
+    intel = true
+else
+    intel = false
 endif
 
-if not enable_asm
+if enable_asm and not intel
+    warning('ASM functions are not available on non-intel machines; disabling.')
+    enable_asm = false
+elif (not enable_asm) and intel
     warning('Install nasm-2.10 or later for a significantly faster libass build.')
-else
+endif
+
+if enable_asm
     conf.set('CONFIG_ASM', 1)
 
     if host_machine.system() == 'windows'

--- a/meson.build
+++ b/meson.build
@@ -123,12 +123,12 @@ if fribidi_dep.found()
     conf.set('CONFIG_FRIBIDI', 1)
 endif
 
-harfbuzz_options = []
+harfbuzz_options = ['tests=disabled']
 if host_machine.system() == 'windows'
     harfbuzz_options += ['glib=disabled', 'gobject=disabled']
 endif
 harfbuzz_dep = dependency('harfbuzz', version: '>= 0.9.5', required: get_option('harfbuzz'),
-                          fallback: 'harfbuzz',
+                          fallback: ['harfbuzz', 'libharfbuzz_dep'],
                           default_options: harfbuzz_options)
 if harfbuzz_dep.found()
     deps += harfbuzz_dep

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,229 @@
+project('libass', 'c', license: 'ISC',
+        meson_version: '>= 0.49.0',
+        default_options: ['c_std=gnu99'],
+        version: '0.14.0')
+
+conf = configuration_data()
+deps = []
+
+if host_machine.system() == 'darwin'
+    add_languages('objc')
+endif
+
+if get_option('large-tiles')
+    conf.set('CONFIG_LARGE_TILES', 1)
+endif
+
+cc = meson.get_compiler('c')
+if cc.get_argument_syntax() == 'gcc'
+    cflags = [
+        '-Wall',
+        '-Wextra',
+        '-Wno-sign-compare',
+        '-Wno-unused-parameter',
+        '-Werror-implicit-function-declaration', 
+        '-Wstrict-prototypes',
+        '-Wpointer-arith',
+        '-Wredundant-decls',
+        '-Wno-missing-field-initializers'
+    ]
+    add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
+endif
+link_args = cc.get_supported_link_arguments(['-prefer-non-pic'])
+
+check_headers = [
+    'dlfcn.h',
+    'iconv.h',
+    'inttypes.h',
+    'memory.h',
+    'stdbool.h',
+    'stdint.h',
+    'stdlib.h',
+    'string.h',
+    'strings.h',
+    'sys/stat.h',
+    'sys/types.h',
+    'unistd.h'
+]
+
+check_functions = [
+    'strdup',
+    'strndup'
+]
+
+m_dep = cc.find_library('m', required: false)
+if m_dep.found()
+    deps += m_dep
+    conf.set('HAVE_LIBM', 1)
+endif
+
+iconv_dep = cc.find_library('iconv', required: false)
+if iconv_dep.found()
+    deps += iconv_dep
+    conf.set('CONFIG_ICONV', 1)
+endif
+
+# ASM
+nasm_args = []
+nasm = find_program('nasm', required: get_option('asm'))
+enable_asm = nasm.found()
+
+if enable_asm
+    # NASM version check
+    nasm_r = run_command(nasm, '-v')
+    out = nasm_r.stdout().strip().split()
+    if out[1].to_lower() == 'version'
+        if out[2].version_compare('< 2.10')
+            warning('nasm is too old (found @0@); ASM functions are disabled.'.format(out[2]))
+            enable_asm = false
+        endif
+    else
+        warning('Unexpected nasm version string: @0@; disabling.'.format(nasm_r.stdout()))
+        enable_asm = false
+    endif
+endif
+
+if enable_asm
+    # Architecture check
+    if host_machine.cpu_family() == 'x86'
+        bittype = '32'
+        nasm_args += '-DARCH_X86_64=0'
+    elif host_machine.cpu_family() == 'x86_64'
+        bittype = '64'
+        nasm_args += ['-DARCH_X86_64=1', '-DPIC']
+    else
+        warning('ASM functions are not available on non-intel machines; disabling.')
+        enable_asm = false
+    endif
+endif
+
+if not enable_asm
+    warning('Install nasm-2.10 or later for a significantly faster libass build.')
+else
+    conf.set('CONFIG_ASM', 1)
+
+    if host_machine.system() == 'windows'
+        nasm_args += ['-f', 'win' + bittype]
+        if bittype == '64'
+            nasm_args += ['-DHAVE_ALIGNED_STACK=1']
+        else
+            nasm_args += ['-DHAVE_ALIGNED_STACK=0', '-DPREFIX']
+        endif
+    elif host_machine.system() == 'darwin'
+        nasm_args += ['-f', 'macho' + bittype, '-DPREFIX', '-DHAVE_ALIGNED_STACK=1']
+    else
+        nasm_args += ['-f', 'elf' + bittype, '-DHAVE_ALIGNED_STACK=1']
+    endif
+
+    nasm_args += ['-DHAVE_CPUNOP=0', '-Dprivate_prefix=ass']
+    nasm_args += ['-I', meson.current_source_dir() / 'libass' + '/', '-o', '@OUTPUT@', '@INPUT@']
+
+    nasm_gen = generator(nasm, output: '@BASENAME@.o', arguments: nasm_args)
+endif
+
+# Misc deps
+# Version info omitted for freetype2 because its versioning is weird and the meson port doesn't handle it properly
+freetype_dep = dependency('freetype', 
+                          fallback: ['freetype2', 'freetype_dep'])
+if freetype_dep.found()
+    deps += freetype_dep
+    conf.set('CONFIG_FREETYPE', 1)
+endif
+
+if get_option('default_library') != 'static' and host_machine.system() == 'windows'
+    fribidi_visibility = '-DFRIBIDI_ENTRY=__declspec(dllexport)'
+else
+    fribidi_visibility = '-DFRIBIDI_ENTRY=extern'
+endif
+fribidi_dep = dependency('fribidi', version: '>= 0.19.0',
+                         fallback: ['fribidi', 'libfribidi_dep'],
+                         default_options: ['docs=false'])
+if fribidi_dep.found()
+    deps += fribidi_dep
+    conf.set('CONFIG_FRIBIDI', 1)
+endif
+
+harfbuzz_dep = dependency('harfbuzz', version: '>= 0.9.5', required: get_option('harfbuzz'),
+                          fallback: ['harfbuzz', 'libharfbuzz_dep'])
+if harfbuzz_dep.found()
+    deps += harfbuzz_dep
+    conf.set('CONFIG_HARFBUZZ', 1)
+endif
+
+fontconfig_dep = dependency('fontconfig', version: '>= 2.10.92', required: get_option('fontconfig'))
+fontconfig = false
+if fontconfig_dep.found()
+    deps += fontconfig_dep
+    conf.set('CONFIG_FONTCONFIG', 1)
+    fontconfig = true
+endif
+
+if get_option('test')
+    deps += dependency('libpng', version: '>= 1.2.0',
+                       fallback: ['libpng', 'png_dep'])
+    conf.set('CONFIG_LIBPNG', 1)
+endif
+
+# DirectWrite
+directwrite = false
+if host_machine.system() == 'windows' and not get_option('directwrite').disabled()
+    if cc.has_header('windows.h')
+        deps += cc.find_library('dwrite', required: true)
+        conf.set('CONFIG_DIRECTWRITE', 1)
+        directwrite = true
+    elif get_option('directwrite').enabled()
+        error('DirectWrite was enabled explicitly, but required header is missing.')
+    endif
+endif
+
+# CoreText
+coretext = false
+if host_machine.system() == 'darwin' and not get_option('coretext').disabled()
+    coretext_dep = dependency('appleframeworks', modules: ['CoreText', 'CoreFoundation'], required: false)
+    if cc.has_type('CTRunRef', prefix: '#include <CoreText/CoreText.h>', dependencies: coretext_dep)
+        deps += coretext_dep
+        conf.set('CONFIG_CORETEXT', 1)
+        coretext = true
+    elif get_option('coretext').enabled()
+        error('CoreText was enabled explicitly, but required headers or frameworks are missing.')
+    endif
+endif
+
+if get_option('require-system-font-provider') and not fontconfig and not directwrite and not coretext
+    error('''Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig (Linux, other) is required.
+If you really want to compile without a system font provider, set -Drequire-system-font-provider=false''')
+endif
+
+foreach name: check_headers
+    if cc.has_header(name)
+        conf.set('HAVE_@0@'.format(name.to_upper().underscorify()), 1)
+    endif
+endforeach
+
+foreach name: check_functions
+    if cc.has_function(name)
+        conf.set('HAVE_@0@'.format(name.to_upper()), 1)
+    endif
+endforeach
+
+conf.set('PACKAGE_NAME', 'libass')
+conf.set('PACKAGE_VERSION', meson.project_version())
+
+config_h = configure_file(output: 'config.h', configuration: conf)
+
+incs = include_directories('.', 'libass')
+
+subdir('libass')
+if get_option('test')
+    subdir('test')
+endif
+if get_option('profile')
+    subdir('profile')
+endif
+
+# libass.pc
+pkg = import('pkgconfig')
+pkg.generate(libass, 
+             name: 'libass',
+             description: 'LibASS is an SSA/ASS subtitles rendering library',
+             subdirs: meson.project_name())

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,11 @@ check_functions = [
     'strndup'
 ]
 
+m_dep = cc.find_library('m', required: false)
+if m_dep.found()
+    deps += m_dep
+endif
+
 iconv_dep = cc.find_library('iconv', required: false)
 if iconv_dep.found()
     deps += iconv_dep
@@ -134,7 +139,13 @@ if harfbuzz_dep.found()
     conf.set('CONFIG_HARFBUZZ', 1)
 endif
 
-fontconfig_dep = dependency('fontconfig', version: '>= 2.10.92', required: get_option('fontconfig'))
+req_fontconfig = get_option('fontconfig')
+
+if host_machine.system() != 'windows' and host_machine.system() != 'darwin'
+    req_fontconfig = get_option('fontconfig').disabled()
+endif
+
+fontconfig_dep = dependency('fontconfig', version: '>= 2.10.92', required: req_fontconfig)
 fontconfig = false
 if fontconfig_dep.found()
     deps += fontconfig_dep

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libass', 'c', license: 'ISC',
-        meson_version: '>= 0.49.0',
+        meson_version: '>= 0.55.0',
         default_options: ['c_std=gnu99'],
         version: '0.15.0')
 

--- a/meson.build
+++ b/meson.build
@@ -37,8 +37,6 @@ elif cc.get_id() != 'msvc'
     add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
 endif
 
-link_args = cc.get_supported_link_arguments(['-prefer-non-pic'])
-
 # Configuration
 
 if get_option('large-tiles')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libass', 'c', license: 'ISC',
         meson_version: '>= 0.55.0',
-        default_options: ['c_std=gnu99', 'buildtype=debugoptimized'],
+        default_options: ['c_std=gnu99', 'buildtype=debugoptimized', 'warning_level=2'],
         version: '0.15.0')
 
 conf = configuration_data()
@@ -17,8 +17,6 @@ endif
 cc = meson.get_compiler('c')
 if cc.get_argument_syntax() == 'gcc'
     cflags = [
-        '-Wall',
-        '-Wextra',
         '-Wno-sign-compare',
         '-Wno-unused-parameter',
         '-Werror-implicit-function-declaration',

--- a/meson.build
+++ b/meson.build
@@ -193,8 +193,7 @@ if host_machine.system() == 'windows' and not cc.has_header('dirent.h')
 endif
 
 foreach name: check_functions
-    # workaround for https://github.com/mesonbuild/meson/issues/3672
-    if cc.has_function(name) and cc.has_header_symbol('string.h', name)
+    if cc.has_function(name)
         conf.set('HAVE_@0@'.format(name.to_upper()), 1)
     endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ if iconv_dep.found() or cc.has_function('iconv_open')
     conf.set('CONFIG_ICONV', 1)
 endif
 
-freetype_dep = dependency('freetype', version: '>= 2.10.92', required: false)
+freetype_dep = dependency('freetype2', version: '>= 2.10.92', required: false)
 if not freetype_dep.found()
     freetype_sp = subproject('freetype2',
                              default_options: ['default_library=' + get_option('default_library'), # workaround for https://github.com/mesonbuild/meson/issues/8047

--- a/meson.build
+++ b/meson.build
@@ -239,5 +239,4 @@ endif
 pkg = import('pkgconfig')
 pkg.generate(libass,
              name: 'libass',
-             description: 'LibASS is an SSA/ASS subtitles rendering library',
-             subdirs: meson.project_name())
+             description: 'LibASS is an SSA/ASS subtitles rendering library')

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,7 @@ project('libass', 'c', license: 'ISC',
 conf = configuration_data()
 deps = []
 
-if get_option('large-tiles')
-    conf.set('CONFIG_LARGE_TILES', 1)
-endif
+# Compiler setup
 
 cc = meson.get_compiler('c')
 if cc.get_argument_syntax() == 'gcc'
@@ -25,10 +23,27 @@ if cc.get_argument_syntax() == 'gcc'
 endif
 link_args = cc.get_supported_link_arguments(['-prefer-non-pic'])
 
+# Configuration
+
+if get_option('large-tiles')
+    conf.set('CONFIG_LARGE_TILES', 1)
+endif
+
+conf.set('PACKAGE_NAME', 'libass')
+conf.set('PACKAGE_VERSION', meson.project_version())
+
 check_functions = [
     'strdup',
     'strndup'
 ]
+
+foreach name: check_functions
+    if cc.has_function(name)
+        conf.set('HAVE_@0@'.format(name.to_upper()), 1)
+    endif
+endforeach
+
+# Dependencies
 
 m_dep = cc.find_library('m', required: false)
 if m_dep.found()
@@ -43,69 +58,6 @@ if iconv_dep.found() or cc.has_function('iconv_open')
     conf.set('CONFIG_ICONV', 1)
 endif
 
-# ASM
-nasm_args = []
-nasm = find_program('nasm', required: get_option('asm'))
-enable_asm = nasm.found()
-
-if enable_asm
-    # NASM version check
-    nasm_r = run_command(nasm, '-v')
-    out = nasm_r.stdout().strip().split()
-    if out[1].to_lower() == 'version'
-        if out[2].version_compare('< 2.10')
-            warning('nasm is too old (found @0@); ASM functions are disabled.'.format(out[2]))
-            enable_asm = false
-        endif
-    else
-        warning('Unexpected nasm version string: @0@; disabling.'.format(nasm_r.stdout()))
-        enable_asm = false
-    endif
-endif
-
-# Architecture check
-if host_machine.cpu_family() == 'x86'
-    bittype = '32'
-    nasm_args += '-DARCH_X86_64=0'
-    intel = true
-elif host_machine.cpu_family() == 'x86_64'
-    bittype = '64'
-    nasm_args += ['-DARCH_X86_64=1', '-DPIC']
-    intel = true
-else
-    intel = false
-endif
-
-if enable_asm and not intel
-    warning('ASM functions are not available on non-intel machines; disabling.')
-    enable_asm = false
-elif (not enable_asm) and intel
-    warning('Install nasm-2.10 or later for a significantly faster libass build.')
-endif
-
-if enable_asm
-    conf.set('CONFIG_ASM', 1)
-
-    if host_machine.system() == 'windows'
-        nasm_args += ['-f', 'win' + bittype]
-        if bittype == '64'
-            nasm_args += ['-DHAVE_ALIGNED_STACK=1']
-        else
-            nasm_args += ['-DHAVE_ALIGNED_STACK=0', '-DPREFIX']
-        endif
-    elif host_machine.system() == 'darwin'
-        nasm_args += ['-f', 'macho' + bittype, '-DPREFIX', '-DHAVE_ALIGNED_STACK=1']
-    else
-        nasm_args += ['-f', 'elf' + bittype, '-DHAVE_ALIGNED_STACK=1']
-    endif
-
-    nasm_args += ['-DHAVE_CPUNOP=0', '-Dprivate_prefix=ass']
-    nasm_args += ['-I', meson.current_source_dir() / 'libass' + '/', '-o', '@OUTPUT@', '@INPUT@']
-
-    nasm_gen = generator(nasm, output: '@BASENAME@.o', arguments: nasm_args)
-endif
-
-# Misc deps
 freetype_dep = dependency('freetype', version: '>= 2.10.92', required: false)
 if not freetype_dep.found()
     freetype_sp = subproject('freetype2',
@@ -196,14 +148,66 @@ if host_machine.system() == 'windows' and not cc.has_header('dirent.h')
     deps += subproject('tronkko-dirent').get_variable('tronkko_dirent_dep')
 endif
 
-foreach name: check_functions
-    if cc.has_function(name)
-        conf.set('HAVE_@0@'.format(name.to_upper()), 1)
-    endif
-endforeach
+# ASM
 
-conf.set('PACKAGE_NAME', 'libass')
-conf.set('PACKAGE_VERSION', meson.project_version())
+nasm_args = []
+nasm = find_program('nasm', required: get_option('asm'))
+enable_asm = nasm.found()
+
+if enable_asm
+    # NASM version check
+    nasm_r = run_command(nasm, '-v')
+    out = nasm_r.stdout().strip().split()
+    if out[1].to_lower() == 'version'
+        if out[2].version_compare('< 2.10')
+            warning('nasm is too old (found @0@); ASM functions are disabled.'.format(out[2]))
+            enable_asm = false
+        endif
+    else
+        warning('Unexpected nasm version string: @0@; disabling.'.format(nasm_r.stdout()))
+        enable_asm = false
+    endif
+endif
+
+# Architecture check
+if host_machine.cpu_family() == 'x86'
+    bittype = '32'
+    nasm_args += '-DARCH_X86_64=0'
+    intel = true
+elif host_machine.cpu_family() == 'x86_64'
+    bittype = '64'
+    nasm_args += '-DARCH_X86_64=1'
+    intel = true
+else
+    intel = false
+endif
+
+if enable_asm and not intel
+    warning('ASM functions are not available on non-intel machines; disabling.')
+    enable_asm = false
+elif (not enable_asm) and intel
+    warning('Install nasm-2.10 or later for a significantly faster libass build.')
+endif
+
+if enable_asm
+    conf.set('CONFIG_ASM', 1)
+
+    if host_machine.system() == 'windows'
+        nasm_args += ['-f', 'win' + bittype]
+        if bittype == '32'
+            nasm_args += '-DPREFIX'
+        endif
+    elif host_machine.system() == 'darwin'
+        nasm_args += ['-f', 'macho' + bittype, '-DPREFIX', '-DSTACK_ALIGNMENT=16']
+    else
+        nasm_args += ['-f', 'elf' + bittype, '-DSTACK_ALIGNMENT=16']
+    endif
+
+    nasm_args += '-Dprivate_prefix=ass'
+    nasm_args += ['-I', meson.current_source_dir() / 'libass' + '/', '-o', '@OUTPUT@', '@INPUT@']
+
+    nasm_gen = generator(nasm, output: '@BASENAME@.o', arguments: nasm_args)
+endif
 
 config_h = configure_file(output: 'config.h', configuration: conf)
 

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ str_check_functions = [
 ]
 
 foreach name: str_check_functions
-    if cc.has_function(name) and cc.has_header_symbol('string.h', name, args: test_args) # might be wrong with MSVC?
+    if cc.has_function(name) and cc.has_header_symbol('string.h', name, args: test_args)
         conf.set('HAVE_@0@'.format(name.to_upper()), 1)
     endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -126,9 +126,9 @@ if fribidi_dep.found()
     conf.set('CONFIG_FRIBIDI', 1)
 endif
 
-harfbuzz_options = ['tests=disabled']
-if host_machine.system() == 'windows'
-    harfbuzz_options += ['glib=disabled', 'gobject=disabled', 'fontconfig=disabled', 'cairo=disabled']
+harfbuzz_options = ['tests=disabled', 'fontconfig=disabled', 'cairo=disabled', 'gobject=disabled']
+if host_machine.system() == 'windows' or host_machine.system() == 'darwin'
+    harfbuzz_options += ['glib=disabled']
 endif
 harfbuzz_dep = dependency('harfbuzz', version: '>= 0.9.5', required: get_option('harfbuzz'),
                           fallback: ['harfbuzz', 'libharfbuzz_dep'],

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,8 @@ endif
 iconv_dep = cc.find_library('iconv', required: false)
 if iconv_dep.found()
     deps += iconv_dep
+endif
+if iconv_dep.found() or cc.has_function('iconv_open')
     conf.set('CONFIG_ICONV', 1)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -179,7 +179,8 @@ If you really want to compile without a system font provider, set -Drequire-syst
 endif
 
 foreach name: check_functions
-    if cc.has_function(name)
+    # workaround for https://github.com/mesonbuild/meson/issues/3672
+    if cc.has_function(name) and cc.has_header_symbol('string.h', name)
         conf.set('HAVE_@0@'.format(name.to_upper()), 1)
     endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -106,7 +106,8 @@ if enable_asm
 endif
 
 # Misc deps
-freetype_dep = dependency('freetype', version: '>= 2.2.1')
+freetype_dep = dependency('freetype', version: '>= 2.2.1',
+                          default_options: ['default_library=' + get_option('default_library')]) # workaround for https://github.com/mesonbuild/meson/issues/8047
 if freetype_dep.found()
     deps += freetype_dep
     conf.set('CONFIG_FREETYPE', 1)

--- a/meson.build
+++ b/meson.build
@@ -187,6 +187,11 @@ if get_option('require-system-font-provider') and not fontconfig and not directw
 If you really want to compile without a system font provider, set -Drequire-system-font-provider=false''')
 endif
 
+# dirent.h
+if host_machine.system() == 'windows' and not cc.has_header('dirent.h')
+    deps += subproject('tronkko-dirent').get_variable('tronkko_dirent_dep')
+endif
+
 foreach name: check_functions
     # workaround for https://github.com/mesonbuild/meson/issues/3672
     if cc.has_function(name) and cc.has_header_symbol('string.h', name)

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ check_functions = [
 ]
 
 foreach name: check_functions
-    if cc.has_function(name)
+    if cc.has_function(name) # TODO: this is probably still wrong
         conf.set('HAVE_@0@'.format(name.to_upper()), 1)
     endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,9 @@ endif
 
 # Misc deps
 freetype_dep = dependency('freetype', version: '>= 2.2.1',
-                          default_options: ['default_library=' + get_option('default_library')]) # workaround for https://github.com/mesonbuild/meson/issues/8047
+                          default_options: ['default_library=' + get_option('default_library'), # workaround for https://github.com/mesonbuild/meson/issues/8047
+                                            'zlib=builtin',
+                                            'png=enabled'])
 if freetype_dep.found()
     deps += freetype_dep
     conf.set('CONFIG_FREETYPE', 1)

--- a/meson.build
+++ b/meson.build
@@ -109,10 +109,15 @@ if freetype_dep.found()
     conf.set('CONFIG_FREETYPE', 1)
 endif
 
-if get_option('default_library') != 'static' and host_machine.system() == 'windows'
-    fribidi_visibility = '-DFRIBIDI_ENTRY=__declspec(dllexport)'
+have_visibility_hidden = cc.has_argument('-fvisibility=hidden')
+if have_visibility_hidden
+    fribidi_visibility = '-DFRIBIDI_ENTRY=extern __attribute__ ((visibility ("default")))'
 else
-    fribidi_visibility = '-DFRIBIDI_ENTRY=extern'
+    if get_option('default_library') != 'static' and host_machine.system() == 'windows'
+        fribidi_visibility = '-DFRIBIDI_ENTRY=__declspec(dllexport)'
+    else
+        fribidi_visibility = '-DFRIBIDI_ENTRY=extern'
+    endif
 endif
 fribidi_dep = dependency('fribidi', version: '>= 0.19.0',
                          fallback: ['fribidi', 'libfribidi_dep'],

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libass', 'c', license: 'ISC',
         meson_version: '>= 0.55.0',
-        default_options: ['c_std=gnu99'],
+        default_options: ['c_std=gnu99', 'buildtype=debugoptimized'],
         version: '0.15.0')
 
 conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -130,7 +130,7 @@ harfbuzz_options = ['tests=disabled', 'fontconfig=disabled', 'cairo=disabled', '
 if host_machine.system() == 'windows' or host_machine.system() == 'darwin'
     harfbuzz_options += ['glib=disabled']
 endif
-harfbuzz_dep = dependency('harfbuzz', version: '>= 0.9.5', required: get_option('harfbuzz'),
+harfbuzz_dep = dependency('harfbuzz', version: '>= 1.2.3', required: get_option('harfbuzz'),
                           fallback: ['harfbuzz', 'libharfbuzz_dep'],
                           default_options: harfbuzz_options)
 if harfbuzz_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -72,14 +72,7 @@ if iconv_dep.found() or cc.has_function('iconv_open')
     conf.set('CONFIG_ICONV', 1)
 endif
 
-freetype_dep = dependency('freetype2', version: '>= 2.10.92', required: false)
-if not freetype_dep.found()
-    freetype_sp = subproject('freetype2',
-                             default_options: ['default_library=' + get_option('default_library'), # workaround for https://github.com/mesonbuild/meson/issues/8047
-                                               'zlib=builtin',
-                                               'png=enabled'])
-    freetype_dep = freetype_sp.get_variable('freetype2_dep')
-endif
+freetype_dep = dependency('freetype2', version: '>= 2.10.92', default_options: ['default_library=' + get_option('default_library')]) # workaround for https://github.com/mesonbuild/meson/issues/8047
 if freetype_dep.found()
     deps += freetype_dep
     conf.set('CONFIG_FREETYPE', 1)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,7 @@ option('directwrite', type: 'feature', description: 'DirectWrite support (win32 
 option('coretext', type: 'feature', description: 'CoreText support (OSX only)')
 option('asm', type: 'feature', description: 'ASM support (better performance)')
 
-option('require-system-font-provider', type: 'boolean', value: true, 
+option('require-system-font-provider', type: 'boolean', value: true,
        description: 'disallow compilation if no system font provider was found')
-option('large-tiles', type: 'boolean', value: false, 
+option('large-tiles', type: 'boolean', value: false,
        description: 'use larger tiles in the rasterizer (better performance, slightly worse quality)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,13 @@
+option('test', type: 'boolean', value: false, description: 'enable test program (requires libpng)')
+option('profile', type: 'boolean', value: false, description: 'enable profiling program')
+
+option('fontconfig', type: 'feature', value: 'disabled', description: 'fontconfig support')
+option('harfbuzz', type: 'feature', description: 'HarfBuzz support')
+option('directwrite', type: 'feature', description: 'DirectWrite support (win32 only)')
+option('coretext', type: 'feature', description: 'CoreText support (OSX only)')
+option('asm', type: 'feature', description: 'ASM support (better performance)')
+
+option('require-system-font-provider', type: 'boolean', value: true, 
+       description: 'disallow compilation if no system font provider was found')
+option('large-tiles', type: 'boolean', value: false, 
+       description: 'use larger tiles in the rasterizer (better performance, slightly worse quality)')

--- a/profile/meson.build
+++ b/profile/meson.build
@@ -1,0 +1,7 @@
+profile_src = files('profile.c')
+
+libass_profile = executable('libass_profile', profile_src,
+                            install: true,
+                            include_directories: incs,
+                            dependencies: deps,
+                            link_with: libass)

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -2,3 +2,6 @@
 directory = freetype2
 url = https://git.savannah.gnu.org/git/freetype/freetype2.git
 revision = master
+
+[provide]
+freetype = freetype2_dep

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -5,3 +5,4 @@ revision = master
 
 [provide]
 freetype = freetype2_dep
+freetype2 = freetype2_dep

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,10 +1,4 @@
-[wrap-file]
-directory = freetype-2.9.1
-
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz
-source_filename = freetype-2.9.1.tar.gz
-source_hash = ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/freetype2/2.9.1/1/get_zip
-patch_filename = freetype2-2.9.1-1-wrap.zip
-patch_hash = 06222607775e707c6d7b8d21ffdb04c7672f676a18c5ebb9880545130ab0407b
+[wrap-git]
+directory = freetype2
+url = https://git.savannah.gnu.org/git/freetype/freetype2.git
+revision = master

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = freetype-2.9.1
+
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.9.1.tar.gz
+source_filename = freetype-2.9.1.tar.gz
+source_hash = ec391504e55498adceb30baceebd147a6e963f636eb617424bcfc47a169898ce
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/freetype2/2.9.1/1/get_zip
+patch_filename = freetype2-2.9.1-1-wrap.zip
+patch_hash = 06222607775e707c6d7b8d21ffdb04c7672f676a18c5ebb9880545130ab0407b

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -4,5 +4,5 @@ url = https://git.savannah.gnu.org/git/freetype/freetype2.git
 revision = master
 
 [provide]
-freetype = freetype2_dep
-freetype2 = freetype2_dep
+freetype = freetype_dep
+freetype2 = freetype_dep

--- a/subprojects/fribidi.wrap
+++ b/subprojects/fribidi.wrap
@@ -2,3 +2,6 @@
 directory = fribidi
 url = https://github.com/fribidi/fribidi.git
 revision = master
+
+[provide]
+fribidi = libfribidi_dep

--- a/subprojects/fribidi.wrap
+++ b/subprojects/fribidi.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = fribidi
+url = https://github.com/fribidi/fribidi.git
+revision = master

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -2,3 +2,6 @@
 directory = harfbuzz
 url = https://github.com/harfbuzz/harfbuzz
 revision = master
+
+[provide]
+harfbuzz = libharfbuzz_dep

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -1,5 +1,4 @@
 [wrap-git]
 directory = harfbuzz
-# Change this URL once upstreamed!
-url = https://github.com/tp-m/harfbuzz.git
-revision = meson-rebased
+url = https://github.com/harfbuzz/harfbuzz
+revision = master

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory = harfbuzz
+# Change this URL once upstreamed!
+url = https://github.com/tp-m/harfbuzz.git
+revision = meson-rebased

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = libpng-1.6.35
+
+source_url = https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz
+source_filename = libpng-1.6.35.tar.gz
+source_hash = 6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.35/5/get_zip
+patch_filename = libpng-1.6.35-5-wrap.zip
+patch_hash = da42b18e8d75a88615bdbc1c7bbf1f739ae19f63a8e70d96c90bc448326ae6b7

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,10 +1,12 @@
 [wrap-file]
-directory = libpng-1.6.35
+directory = libpng-1.6.37
+source_url = https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
+source_filename = libpng-1.6.37.tar.gz
+source_hash = ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.37/2/get_zip
+patch_filename = libpng-1.6.37-2-wrap.zip
+patch_hash = c9dde143db819e803c9d59628863a9c8ea34f84b7e8e28e3d881502a5747ec56
 
-source_url = https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz
-source_filename = libpng-1.6.35.tar.gz
-source_hash = 6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210
+[provide]
+libpng = libpng_dep
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.35/5/get_zip
-patch_filename = libpng-1.6.35-5-wrap.zip
-patch_hash = da42b18e8d75a88615bdbc1c7bbf1f739ae19f63a8e70d96c90bc448326ae6b7

--- a/subprojects/tronkko-dirent.wrap
+++ b/subprojects/tronkko-dirent.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = dirent-1.23.2
+
+source_url = https://github.com/tronkko/dirent/archive/1.23.2.tar.gz
+source_filename = dirent-1.23.2.tar.gz
+source_hash = f72d39e3c39610b6901e391b140aa69b51e0eb99216939ed5e547b5dad03afb1
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/tronkko-dirent/1.23.2/1/get_zip
+patch_filename = tronkko-dirent-1.23.2-1-wrap.zip
+patch_hash = 036957f6dee31d0b92f14cf3676d13baf44e9a1be950c248468440ffc40c78a4

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = zlib-1.2.11
+
+source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/3/get_zip
+patch_filename = zlib-1.2.11-3-wrap.zip
+patch_hash = f07dc491ab3d05daf00632a0591e2ae61b470615b5b73bcf9b3f061fff65cff0

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,10 +1,12 @@
 [wrap-file]
 directory = zlib-1.2.11
-
 source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
 source_filename = zlib-1.2.11.tar.gz
 source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/5/get_zip
+patch_filename = zlib-1.2.11-5-wrap.zip
+patch_hash = 728c8e24acbc2e6682fbd950fec39e2fc77528af361adb87259f8a8511434004
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/3/get_zip
-patch_filename = zlib-1.2.11-3-wrap.zip
-patch_hash = f07dc491ab3d05daf00632a0591e2ae61b470615b5b73bcf9b3f061fff65cff0
+[provide]
+zlib = zlib_dep
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,7 @@
+test_src = files('test.c')
+
+libass_test = executable('libass_test', test_src,
+                         install: true,
+                         include_directories: incs,
+                         dependencies: deps,
+                         link_with: libass)


### PR DESCRIPTION
For your consideration.

Makes `--force-fallback-for=freetype2` work. Tested with default_library set to static and shared to ensure only the correct library is built.